### PR TITLE
Only build the benchmarking tool when the bench dune profile is used

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,9 +34,9 @@ jobs:
 
       - run: opam install . --deps-only --with-test
 
-      - run: opam exec -- dune build -p notty-community
+      - run: opam exec -- dune build
 
-      - run: opam exec -- dune runtest -p notty-community
+      - run: opam exec -- dune runtest
 
   lint-doc:
     runs-on: ubuntu-latest

--- a/benchmarks/dune
+++ b/benchmarks/dune
@@ -1,3 +1,4 @@
 (executable
   (name speed)
+  (enabled_if (= %{profile} "bench"))
   (libraries notty-community notty-community.unix common unmark unmark.cli))

--- a/notty-community.opam
+++ b/notty-community.opam
@@ -22,6 +22,7 @@ depends: [
   "cppo" {build & >= "1.1.0"}
   "uutf" {>= "1.0.0"}
   "uucp" {with-dev-setup}
+  "lwt" {with-test}
   "odoc" {with-doc}
 ]
 depopts: ["lwt"]


### PR DESCRIPTION
unmark (used in the benchmark) is unreleased so doing that allows to run `dune build @all`